### PR TITLE
Support benchmarked functions with comptime args

### DIFF
--- a/bench.zig
+++ b/bench.zig
@@ -35,7 +35,7 @@ pub fn benchmark(comptime B: type) !void {
         var res = [_]u64{ 0, 0, 0 };
         res = try printBenchmark(writer, res, "Benchmark", "", "Iterations", "Mean(ns)");
         inline for (functions) |f| {
-            for (args) |_, i| {
+            inline for (args) |_, i| {
                 res = if (i < arg_names.len)
                     try printBenchmark(writer, res, f.name, arg_names[i], math.maxInt(u32), math.maxInt(u32))
                 else
@@ -56,7 +56,7 @@ pub fn benchmark(comptime B: type) !void {
 
     var timer = try time.Timer.start();
     inline for (functions) |def| {
-        for (args) |arg, index| {
+        inline for (args) |arg, index| {
             var runtime_sum: u128 = 0;
 
             var i: usize = 0;

--- a/bench.zig
+++ b/bench.zig
@@ -176,3 +176,33 @@ test "benchmark" {
         }
     });
 }
+
+test "benchmark generics" {
+    try benchmark(struct {
+        const Vec = @import("std").meta.Vector;
+
+        pub const args = [_]type{
+            Vec(4, f16),  Vec(4, f32),  Vec(4, f64),
+            Vec(8, f16),  Vec(8, f32),  Vec(8, f64),
+            Vec(16, f16), Vec(16, f32), Vec(16, f64),
+        };
+
+        pub const arg_names = [_][]const u8{
+            "vec4f16",  "vec4f32",  "vec4f64",
+            "vec8f16",  "vec8f32",  "vec8f64",
+            "vec16f16", "vec16f32", "vec16f64",
+        };
+
+        pub fn sum_vectors(comptime T: type) T {
+            const info = @typeInfo(T).Vector;
+            const one = @splat(info.len, @as(info.child, 1));
+            var vecs: [512]T = [1]T{one} ** 512;
+            var res = one;
+
+            for (vecs) |vec| {
+                res += vec;
+            }
+            return res;
+        }
+    });
+}

--- a/bench.zig
+++ b/bench.zig
@@ -35,7 +35,8 @@ pub fn benchmark(comptime B: type) !void {
         var res = [_]u64{ 0, 0, 0 };
         res = try printBenchmark(writer, res, "Benchmark", "", "Iterations", "Mean(ns)");
         inline for (functions) |f| {
-            inline for (args) |_, i| {
+            var i: usize = 0;
+            while (i < args.len) : (i += 1) {
                 res = if (i < arg_names.len)
                     try printBenchmark(writer, res, f.name, arg_names[i], math.maxInt(u32), math.maxInt(u32))
                 else


### PR DESCRIPTION
I wanted to run benchmarks over generics, with their type as one of the criteria, which requires the processing of `args` to also be inlined at compile time.
